### PR TITLE
Fix PHP 7.3 compatibility

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -63,6 +63,6 @@ class Parser
 
     private function isValidPhpInfoHtml()
     {
-        return $this->xpath->query('//head//title')[0]->nodeValue === 'phpinfo()';
+        return strpos($this->xpath->query('//head//title')[0]->nodeValue, 'phpinfo()') !== false;
     }
 }


### PR DESCRIPTION
PHP 7.3 `phpinfo()` pages have version numbers in their titles:

 - `PHP 7.3.0 - phpinfo()`
 - `‌PHP 7.3.0-2+ubuntu16.04.1+deb.sury.org+1 - phpinfo()`

So we should instead check whether `phpinfo()` is present anywhere in the string.

Fixing this (and releasing a new version) should resolve https://github.com/phpversions/phpversions.info/issues/515.